### PR TITLE
Update build system requirements in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.8.0,<0.9"]
+requires = ["uv_build>=0.8.22,<0.9.0"]
 build-backend = "uv_build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.8.0,<0.9"]
+build-backend = "uv_build"
 
 [project]
 name = "devtul"
@@ -22,7 +22,7 @@ dependencies = [
 where = ["src"]
 
 [project.optional-dependencies]
-build = ["pyinstaller"]
+build = ["uv_build>=0.8.22,<0.9.0"]
 
 [project.scripts]
 devtul = "devtul.main:main"


### PR DESCRIPTION
This pull request updates the build system and related dependencies in the `pyproject.toml` file to use `uv_build` instead of `setuptools`. The main changes focus on modernizing the build backend and ensuring compatibility with the latest tooling.

**Build system migration:**

* Switched the build backend from `setuptools` to `uv_build` and updated the required version range in the `[build-system]` section.

**Dependency updates:**

* Updated the `build` optional dependency to require `uv_build` with a specific version range, replacing `pyinstaller`.